### PR TITLE
Solve missing warn error

### DIFF
--- a/chspy/_chspy.py
+++ b/chspy/_chspy.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from bisect import insort, bisect_left
+from warnings import warn
 
 def rel_dist(x,y):
 	x = np.asarray(x)


### PR DESCRIPTION
Just bump into this when using twice `constant_past` in JITCDDE.

Thanks for your amazing tools!