### PR TITLE
find time at which derivative of spline reaches a given value 

### DIFF
--- a/chspy/_chspy.py
+++ b/chspy/_chspy.py
@@ -325,6 +325,8 @@ def solve_from_anchors(anchors,i,value,beginning=None,end=None,target='state'):
 			2*(-3*p0 - 2*m0 + 3*p1 - m1),
 			m0-value*q,
 		])
+	else:
+		raise ValueError("Invalid target for solve method. Supported targets are 'state' and 'diff'.")
 
 	solutions = sorted(
 			retransform(candidate.real)

--- a/chspy/_chspy.py
+++ b/chspy/_chspy.py
@@ -279,7 +279,7 @@ def extrema_from_anchors(anchors,beginning=None,end=None,target=None):
 	
 	return extrema
 
-def solve_from_anchors(anchors,i,value,beginning=None,end=None):
+def solve_from_anchors(anchors,i,value,beginning=None,end=None,target='state'):
 	"""
 	Finds the times at which a component of the Hermite interpolant for the anchors assumes a given value and the derivatives at those points (allowing to distinguish upwards and downwards threshold crossings).
 	
@@ -293,30 +293,39 @@ def solve_from_anchors(anchors,i,value,beginning=None,end=None):
 		Beginning of the time interval for which positions are returned. If `None`, the time of the first anchor is used.
 	end : float or `None`
 		End of the time interval for which positions are returned. If `None`, the time of the last anchor is used.
+	target : string
+			The spline value to solve for: 'state' or 'diff'. Defaults to 'state'. 
 	
 	Returns
 	-------
 	positions : list of pairs of floats
 		Each pair consists of a time where `value` is assumed and the derivative (of `component`) at that time.
 	"""
-	
+		
 	q = (anchors[1].time-anchors[0].time)
 	retransform = lambda x: q*x+anchors[0].time
-	a = anchors[0].state[i]
-	b = anchors[0].diff[i] * q
-	c = anchors[1].state[i]
-	d = anchors[1].diff[i] * q
+	p0 = anchors[0].state[i]
+	m0 = anchors[0].diff[i] * q
+	p1 = anchors[1].state[i]
+	m1 = anchors[1].diff[i] * q
 	
 	left_x  = 0 if beginning is None else (beginning-anchors[0].time)/q
 	right_x = 1 if end       is None else (end      -anchors[0].time)/q
 	
-	candidates = np.roots([
-			2*a + b - 2*c + d,
-			-3*a - 2*b + 3*c - d,
-			b,
-			a - value,
+	if target == 'state':
+		candidates = np.roots([
+				2*p0 + m0 - 2*p1 + m1,
+				-3*p0 - 2*m0 + 3*p1 - m1,
+				m0,
+				p0 - value,
+			])
+	elif target == 'diff':
+		candidates = np.roots([
+			3*(2*p0 + m0 - 2*p1 + m1),
+			2*(-3*p0 - 2*m0 + 3*p1 - m1),
+			m0-value*q,
 		])
-	
+
 	solutions = sorted(
 			retransform(candidate.real)
 			for candidate in candidates
@@ -706,7 +715,7 @@ class CubicHermiteSpline(list):
 		
 		return extrema
 
-	def solve(self,i,value,beginning=None,end=None):
+	def solve(self,i,value,beginning=None,end=None,target='state'):
 		"""
 		Finds the times at which a component of the spline assumes a given value and the derivatives at those points (allowing to distinguish upwards and downwards threshold crossings). This will not work well if the spline is constantly at the given value for some interval.
 		
@@ -720,7 +729,8 @@ class CubicHermiteSpline(list):
 			Beginning of the time interval for which solutions are returned. If `None`, the time of the first anchor is used.
 		end : float or `None`
 			End of the time interval for which solutions are returned. If `None`, the time of the last anchor is used.
-		
+		target : string
+			The spline value to solve for: 'state' or 'diff'. Defaults to 'state'. 
 		Returns
 		-------
 		positions : list of pairs of floats
@@ -740,13 +750,14 @@ class CubicHermiteSpline(list):
 		for j in range(self.last_index_before(beginning),len(self)-1):
 			if self[j].time>end:
 				break
-			
+	
 			new_sols = solve_from_anchors(
 					anchors = ( self[j], self[j+1] ),
 					i = i,
 					value = value,
 					beginning = max( beginning, self[j  ].time ),
 					end       = min( end      , self[j+1].time ),
+					target = target,
 				)
 			
 			if sols and new_sols and sols[-1][0]==new_sols[0][0]:

--- a/tests/test_hermite_spline.py
+++ b/tests/test_hermite_spline.py
@@ -5,6 +5,7 @@ from chspy import CubicHermiteSpline, scalar_product_interval, scalar_product_pa
 from chspy._chspy import rel_dist
 
 import symengine
+import sympy
 import numpy as np
 from numpy.testing import assert_allclose
 import unittest
@@ -269,57 +270,33 @@ class extrema_test(unittest.TestCase):
 
 class TestSolving(unittest.TestCase):
 	def test_random_function(self):
-		roots = np.sort(np.random.normal(size=5))
-		value = np.random.normal()
-		t = symengine.Symbol("t")
-		function = np.prod([t-root for root in roots]) + value
-		
-		i = 1
-		spline = CubicHermiteSpline.from_func(
-				[10,function,10],
-				times_of_interest = ( min(roots)-0.01, max(roots)+0.01 ),
-				max_anchors = 1000,
-				tol = 7,
-			)
-		
-		solutions = spline.solve(i=i,value=value)
-		sol_times = [ sol[0] for sol in solutions ]
-		assert_allclose( spline.get_state(sol_times)[:,i], value )
-		assert_allclose( [sol[0] for sol in solutions], roots, atol=1e-3 )
-		for time,diff in solutions:
-			true_diff = float(function.diff(t).subs({t:time}))
-			self.assertAlmostEqual( true_diff, diff, places=5 )
-
-	def test_solve_with_target(self):
-		roots = np.sort(np.random.normal(size=5))
-		value = np.random.normal()
-		t = symengine.Symbol("t")
-		function = np.prod([t - root for root in roots]) + value
-		diff_function = function.diff(t)
-
-		i = 1
-		spline = CubicHermiteSpline.from_func(
-			[10, function, 10],
-			times_of_interest=(min(roots) - 0.01, max(roots) + 0.01),
-			max_anchors=1000,
-			tol=7,
-		)
-
-		# test for target='state'
-		state_solutions = spline.solve(i=i, value=value, target='state')
-		state_sol_times = [sol[0] for sol in state_solutions]
-		assert_allclose(spline.get_state(state_sol_times)[:, i], value)
-		assert_allclose([sol[0] for sol in state_solutions], roots, atol=1e-3)
-		for time, diff in state_solutions:
-			true_diff = float(function.diff(t).subs({t: time}))
-			self.assertAlmostEqual(true_diff, diff, places=5)
-
-		# test for target='diff'
-		diff_value = np.random.normal()  
-		diff_solutions = spline.solve(i=i, value=diff_value, target='diff')
-		for time, diff in diff_solutions:
-			true_diff = float(diff_function.subs({t: time}))
-			self.assertAlmostEqual(true_diff, diff, places=5)
+		for solve_derivative in [False,True]:
+			roots = np.sort(np.random.normal(size=5))
+			value = np.random.normal()
+			t = symengine.Symbol("t")
+			function = np.prod([t-root for root in roots]) + value
+			if solve_derivative:
+				function = sympy.integrate(function,[t]) + np.random.random()
+			
+			i = 1
+			spline = CubicHermiteSpline.from_func(
+					[10,function,10],
+					times_of_interest = ( min(roots)-0.01, max(roots)+0.01 ),
+					max_anchors = 1000,
+					tol = 7,
+				)
+			
+			solutions = spline.solve(i=i,value=value,solve_derivative=solve_derivative)
+			sol_times = [ sol[0] for sol in solutions ]
+			assert_allclose( sol_times, roots, atol=1e-3 )
+			if solve_derivative:
+				for time,diff in solutions:
+					self.assertAlmostEqual( value, diff, places=5 )
+			else:
+				assert_allclose( spline.get_state(sol_times)[:,i], value )
+				for time,diff in solutions:
+					true_diff = float(function.diff(t).subs({t:time}))
+					self.assertAlmostEqual( true_diff, diff, places=5 )
 
 class TimeSeriesTest(unittest.TestCase):
 	def test_comparison(self):


### PR DESCRIPTION
### Summary
This pr adds an argument called `target` to the `solve()` method of the `CubicHermiteSpline()`, which allows the user to solve for when the derivative of the component of a spline reaches a given value. Prior behavior, i.e. solving for when the state of the component reaches a given value, is maintained as default. 

### Motivation
I'm using `jitcdde` to model some control strategies, some of which are based on state, where this `solve()` method becomes useful to pinpoint the exact time an event happened. Some other strategies are based on the derivatives of state variables. Therefore to pinpoint the timing of these events requires some extra logic. 

### Approach
To solve for the time at which a given component reaches a given value we solve for the roots of the polynomial:

$at^3 + bt^2 + ct +(d-\text{value})$

Where $a,b,c,d$ can be computed from the anchors. To do the same for the derivative is therefore straightforward, and implemented as finding the roots of the polynomial:

$3at^2 + 2bt + (c-\text{value} \cdot \Delta t)$

where $\Delta t$ is the timestep between the anchors.

### Changes
- Changed the variable names representing the state and derivative at the anchor points for clarity. I found that $a,b,c,d$ are often used in the literature to express the coefficients of the Hermite polynomial, which was then confusing to use them to compute these coefficients 
- Added optional argument `target` to the `solve()` method of the `CubicHermiteSpline` class
- Similarly added optional argument `target` to the `solve_from_anchors()` function, and the necessary logic in this function to interpolate the time at which this derivative is reached. 
- Added a some tests within the `TestSolving` class of the test suite