### PR TITLE
Small doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cubic Hermite Splines for Python
 
 This module provides Python tools for cubic Hermite splines with one argument (time) and multiple values.
-It was branched of from [JiTCDDE](http://github.com/neurophysik/jitcdde), which uses it for representing the past of a delay differential equation.
+It was branched of from [JiTCDDE](https://github.com/neurophysik/jitcdde), which uses it for representing the past of a delay differential equation.
 
 You can find the documentation [on Read the Docs](https://chspy.readthedocs.io).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,11 @@
 CHSPy (Cubic Hermite Splines for Python)
 ========================================
 
-This module provides Python tools for `cubic Hermite splines <https://en.wikipedia.org/wiki/Cubic_Hermite_spline>`_ with one argument (time) and multiple values (:math:`ℝ→ℝ^n`).
-It was branched of from `JiTCDDE <http://github.com/neurophysik/jitcdde>`_, which uses it for representing the past of a delay differential equation.
+This module provides Python tools for `cubic Hermite splines <https://en.wikipedia.org/wiki/Cubic_Hermite_spline>`__ with one argument (time) and multiple values (:math:`ℝ→ℝ^n`).
+It was branched of from `JiTCDDE <https://github.com/neurophysik/jitcdde>`__, which uses it for representing the past of a delay differential equation.
 CHSPy is not optimised for efficiency, however it should be fairly effective for high-dimensionally valued splines.
 
-Each spline (`CubicHermiteSpline`) is stored as a series of *anchors* (using the `Anchor` class) each of which contains:
+Each spline (:class:`~_chspy.CubicHermiteSpline`) is stored as a series of *anchors* (using the :class:`~_chspy.Anchor` class) each of which contains:
 
 * a time point (`time`),
 * an :math:`n`-dimensional state (`state`),


### PR DESCRIPTION
Was looking through the docs a bit after https://github.com/neurophysik/jitcode/pull/43#issuecomment-2602589963. This fixes some small issues
* Using ``"`Text <URL>`_"`` with a single underscore at the end creates a named hyperlink in rst. Creating an anonymous one with a double underscore is better for these one-off links.
* Using just ``"`text`"`` uses the default role in Sphinx. This is ok for random text, but classes / functions / etc should be referred to explicitly using ``":class:`Name`"``.
* Updates some links to HTTPS.