### PR TITLE
Fix new error from ruff 0.10

### DIFF
--- a/chspy/_chspy.py
+++ b/chspy/_chspy.py
@@ -521,7 +521,7 @@ class CubicHermiteSpline(list):
 				raise ValueError("Expressions must contain at most one free symbol")
 			
 			def get_anchor(time):
-				substitutions = {symbol:time for symbol in symbols}
+				substitutions = dict.fromkeys(symbols, time)
 				evaluate = lambda expr: expr.subs(substitutions).evalf(tol)
 				return unhappy_anchor(
 						time,


### PR DESCRIPTION
The new version of ruff caught this error: https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/